### PR TITLE
Implement ibv_create_cq_ex()

### DIFF
--- a/def/efawin.def
+++ b/def/efawin.def
@@ -38,6 +38,7 @@ EXPORTS
     ibv_destroy_cq
     ibv_wc_status_str
     ibv_create_cq
+    ibv_create_cq_ex
     ibv_open_device
     ibv_get_device_list
     ibv_close_device

--- a/efawin/efawin.c
+++ b/efawin/efawin.c
@@ -131,6 +131,13 @@ struct ibv_cq* ibv_create_cq(struct ibv_context* context, int cqe,
     return cq;
 }
 
+struct ibv_cq_ex* ibv_create_cq_ex(struct ibv_context* context, struct ibv_cq_init_attr_ex *cq_attr)
+{
+    struct ibv_cq_ex* cq = efa_ctx_ops.create_cq_ex(context, cq_attr);
+    cq->cq_context = context;
+    return cq;
+}
+
 const char* ibv_wc_status_str(enum ibv_wc_status status)
 {
     // WC status mapping is not supported

--- a/interface/efawin.c
+++ b/interface/efawin.c
@@ -35,7 +35,6 @@
 #include <inttypes.h>
 #include <infiniband/verbs.h>
 #include <efawinver.h>
-
 HMODULE hEfawinLib = NULL;
 
 /*
@@ -144,6 +143,11 @@ struct ibv_cq* dummy_create_cq(struct ibv_context* context, int cqe,
     return NULL;
 }
 
+struct ibv_cq* dummy_create_cq_ex(struct ibv_context* context, struct ibv_cq_init_attr_ex *cq_attr)
+{
+    return NULL;
+}
+
 const char* dummy_wc_status_str(enum ibv_wc_status status)
 {
     return NULL;
@@ -204,6 +208,7 @@ struct efawin_ops {
     efa_win_get_device_list_fn efa_win_get_device_list;
     efa_win_open_device_fn efa_win_open_device;
     efa_win_create_cq_fn efa_win_create_cq;
+    efa_win_create_cq_ex_fn efa_win_create_cq_ex;
     efa_win_wc_status_str_fn efa_win_wc_status_str;
     efa_win_destroy_cq_fn efa_win_destroy_cq;
     efa_win_destroy_ah_fn efa_win_destroy_ah;
@@ -232,6 +237,7 @@ struct efawin_ops efawin_ops = {
     .efa_win_get_device_list = dummy_get_device_list,
     .efa_win_open_device = dummy_open_device,
     .efa_win_create_cq = dummy_create_cq,
+    .efa_win_create_cq_ex = dummy_create_cq_ex,
     .efa_win_wc_status_str = dummy_wc_status_str,
     .efa_win_destroy_cq = dummy_destroy_cq,
     .efa_win_destroy_ah = dummy_destroy_ah,
@@ -269,6 +275,7 @@ int efa_load_efawin_lib()
     efa_win_get_device_list_fn efa_win_get_device_list;
     efa_win_open_device_fn efa_win_open_device;
     efa_win_create_cq_fn efa_win_create_cq;
+    efa_win_create_cq_ex_fn efa_win_create_cq_ex;
     efa_win_wc_status_str_fn efa_win_wc_status_str;
     efa_win_destroy_cq_fn efa_win_destroy_cq;
     efa_win_destroy_ah_fn efa_win_destroy_ah;
@@ -368,6 +375,12 @@ int efa_load_efawin_lib()
     if (!efa_win_create_cq) {
         goto liberror;
     }
+
+    efa_win_create_cq_ex = (efa_win_create_cq_ex_fn)GetProcAddress(hEfawinLib, "ibv_create_cq_ex");
+    if (!efa_win_create_cq_ex) {
+        goto liberror;
+    }
+
     efa_win_wc_status_str = (efa_win_wc_status_str_fn)GetProcAddress(hEfawinLib, "ibv_wc_status_str");
     if (!efa_win_wc_status_str) {
         goto liberror;
@@ -416,6 +429,7 @@ int efa_load_efawin_lib()
     efawin_ops.efa_win_get_device_list = efa_win_get_device_list;
     efawin_ops.efa_win_open_device = efa_win_open_device;
     efawin_ops.efa_win_create_cq = efa_win_create_cq;
+    efawin_ops.efa_win_create_cq_ex = efa_win_create_cq_ex;
     efawin_ops.efa_win_wc_status_str = efa_win_wc_status_str;
     efawin_ops.efa_win_destroy_cq = efa_win_destroy_cq;
     efawin_ops.efa_win_destroy_ah = efa_win_destroy_ah;
@@ -535,6 +549,11 @@ struct ibv_cq* ibv_create_cq(struct ibv_context* context, int cqe,
     int comp_vector)
 {
     return efawin_ops.efa_win_create_cq(context, cqe, cq_context, channel, comp_vector);
+}
+
+struct ibv_cq_ex *ibv_create_cq_ex(struct ibv_context* context, struct ibv_cq_init_attr_ex *cq_attr)
+{
+    return efawin_ops.efa_win_create_cq_ex(context, cq_attr);
 }
 
 const char* ibv_wc_status_str(enum ibv_wc_status status)

--- a/interface/efawinver.h
+++ b/interface/efawinver.h
@@ -62,6 +62,8 @@ typedef struct ibv_cq* (*efa_win_create_cq_fn)(struct ibv_context* context, int 
     struct ibv_comp_channel* channel,
     int comp_vector);
 
+typedef struct ibv_cq_ex* (*efa_win_create_cq_ex_fn)(struct ibv_context* context, struct ibv_cq_init_attr_ex *cq_attr);
+
 typedef const char* (*efa_win_wc_status_str_fn)(enum ibv_wc_status status);
 
 typedef int (*efa_win_destroy_cq_fn)(struct ibv_cq* cq);

--- a/interface/infiniband/verbs.h
+++ b/interface/infiniband/verbs.h
@@ -46,6 +46,7 @@
 #include <efacompat.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <stdio.h>
 #include <infiniband/verbs_api.h>
 
 
@@ -2787,19 +2788,8 @@ struct ibv_cq *ibv_create_cq(struct ibv_context *context, int cqe,
  * @context - Context CQ will be attached to
  * @cq_attr - Attributes to create the CQ with
  */
-static inline
 struct ibv_cq_ex *ibv_create_cq_ex(struct ibv_context *context,
-				   struct ibv_cq_init_attr_ex *cq_attr)
-{
-	struct verbs_context *vctx = verbs_get_ctx_op(context, create_cq_ex);
-
-	if (!vctx) {
-		errno = EOPNOTSUPP;
-		return NULL;
-	}
-
-	return vctx->create_cq_ex(context, cq_attr);
-}
+				   struct ibv_cq_init_attr_ex *cq_attr);
 
 /**
  * ibv_resize_cq - Modifies the capacity of the CQ.


### PR DESCRIPTION
This patch implement the rdma-core API ibv_create_cq_ex by simply calling efa_create_cq_ex




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
